### PR TITLE
require('sys') => require('util')

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
  * Fichier principal
  */
 var wsclient = require('websocket').client,
-    sys = require('sys'),
+    util = require('util'),
     https = require('https');
 
 global.Parser = require('./parser.js').Parser;


### PR DESCRIPTION
Le module sys est devenu obsolèt il y a quatre années avec la sortie de Node.js v0.6.0, qui l'a remplacé avec celui util.